### PR TITLE
Code generated for equals, hashCode, toString handles the no fields case

### DIFF
--- a/src/main/java/dev/mccue/magicbean/processor/AnnotationProcessor.java
+++ b/src/main/java/dev/mccue/magicbean/processor/AnnotationProcessor.java
@@ -72,7 +72,7 @@ public final class AnnotationProcessor extends AbstractProcessor {
                                         
                         """.formatted(
                         className,
-                        createEqualsExpressions(selfExpr, fields)
+                        createEqualsExpression(selfExpr, fields)
                 )
         );
         equalsAndHashCodeMethods.append("""
@@ -88,31 +88,35 @@ public final class AnnotationProcessor extends AbstractProcessor {
         return equalsAndHashCodeMethods.toString();
     }
 
-    private String createEqualsExpressions(String selfExpr, List<VariableElement> fields) {
-        if (fields.isEmpty())
+    private String createEqualsExpression(String selfExpr, List<VariableElement> fields) {
+        if (fields.isEmpty()) {
             return "super.equals(o)";
-
-        return fields.stream()
-                .map(field -> "java.util.Objects.equals(%s.%s, other.%s)".formatted(
-                        selfExpr,
-                        field.getSimpleName(),
-                        field.getSimpleName()
-                ))
-                .collect(Collectors.joining(" && \n                   "));
+        }
+        else {
+            return fields.stream()
+                    .map(field -> "java.util.Objects.equals(%s.%s, other.%s)".formatted(
+                            selfExpr,
+                            field.getSimpleName(),
+                            field.getSimpleName()
+                    ))
+                    .collect(Collectors.joining(" && \n                   "));
+        }
     }
 
     private String createHashMethodBody(String selfExpr, List<VariableElement> fields) {
-        if (fields.isEmpty())
+        if (fields.isEmpty()) {
             return "return super.hashCode();";
-
-        return """
-                return java.util.Objects.hash(
-                                  %s
-                                );
-                """.formatted(
-                fields.stream()
-                        .map(field -> "      " + selfExpr + "." + field.getSimpleName())
-                        .collect(Collectors.joining(",\n          ")));
+        }
+        else {
+            return """
+                    return java.util.Objects.hash(
+                                      %s
+                                    );
+                    """.formatted(
+                    fields.stream()
+                            .map(field -> "      " + selfExpr + "." + field.getSimpleName())
+                            .collect(Collectors.joining(",\n          ")));
+        }
     }
 
     private String toStringMethod(String selfExpr, Name className, List<VariableElement> fields) {
@@ -128,21 +132,26 @@ public final class AnnotationProcessor extends AbstractProcessor {
     }
 
     private String createToStringMethodBody(String selfExpr, Name className, List<VariableElement> fields) {
-        if (fields.isEmpty())
-            return "return super.toString();";
-
-        return """
-                return "%s[" + %s + "]";
-                """.formatted(
-                className,
-                fields.stream()
-                        .map(field ->
-                                "\"%s=\" + %s".formatted(
-                                        field.getSimpleName(),
-                                        selfExpr + "." + field.getSimpleName()
-                                )
-                        )
-                        .collect(Collectors.joining(" +\n                     \", \" + ")));
+        if (fields.isEmpty()) {
+            return """
+                    return "%s[]";
+                    """.formatted(
+                    className);
+        }
+        else {
+            return """
+                    return "%s[" + %s + "]";
+                    """.formatted(
+                    className,
+                    fields.stream()
+                            .map(field ->
+                                    "\"%s=\" + %s".formatted(
+                                            field.getSimpleName(),
+                                            selfExpr + "." + field.getSimpleName()
+                                    )
+                            )
+                            .collect(Collectors.joining(" +\n                     \", \" + ")));
+        }
     }
 
     @Override

--- a/src/main/java/dev/mccue/magicbean/processor/AnnotationProcessor.java
+++ b/src/main/java/dev/mccue/magicbean/processor/AnnotationProcessor.java
@@ -82,7 +82,7 @@ public final class AnnotationProcessor extends AbstractProcessor {
                             }
                         
                         """.formatted(
-                        createHashMethodBody(selfExpr, fields)
+                        createHashCodeMethodBody(selfExpr, fields)
                 )
         );
         return equalsAndHashCodeMethods.toString();
@@ -103,7 +103,7 @@ public final class AnnotationProcessor extends AbstractProcessor {
         }
     }
 
-    private String createHashMethodBody(String selfExpr, List<VariableElement> fields) {
+    private String createHashCodeMethodBody(String selfExpr, List<VariableElement> fields) {
         if (fields.isEmpty()) {
             return "return super.hashCode();";
         }

--- a/src/main/java/dev/mccue/magicbean/processor/AnnotationProcessor.java
+++ b/src/main/java/dev/mccue/magicbean/processor/AnnotationProcessor.java
@@ -90,7 +90,7 @@ public final class AnnotationProcessor extends AbstractProcessor {
 
     private String createEqualsExpression(String selfExpr, List<VariableElement> fields) {
         if (fields.isEmpty()) {
-            return "super.equals(o)";
+            return "true";
         }
         else {
             return fields.stream()
@@ -105,7 +105,7 @@ public final class AnnotationProcessor extends AbstractProcessor {
 
     private String createHashCodeMethodBody(String selfExpr, List<VariableElement> fields) {
         if (fields.isEmpty()) {
-            return "return super.hashCode();";
+            return "return 1;";
         }
         else {
             return """

--- a/src/main/java/dev/mccue/magicbean/processor/AnnotationProcessor.java
+++ b/src/main/java/dev/mccue/magicbean/processor/AnnotationProcessor.java
@@ -110,9 +110,8 @@ public final class AnnotationProcessor extends AbstractProcessor {
         else {
             return """
                     return java.util.Objects.hash(
-                                      %s
-                                    );
-                    """.formatted(
+                              %s
+                            );""".formatted(
                     fields.stream()
                             .map(field -> "      " + selfExpr + "." + field.getSimpleName())
                             .collect(Collectors.joining(",\n          ")));
@@ -133,15 +132,12 @@ public final class AnnotationProcessor extends AbstractProcessor {
 
     private String createToStringMethodBody(String selfExpr, Name className, List<VariableElement> fields) {
         if (fields.isEmpty()) {
-            return """
-                    return "%s[]";
-                    """.formatted(
-                    className);
+            return "return \"%s[]\"; "
+                    .formatted(className);
         }
         else {
-            return """
-                    return "%s[" + %s + "]";
-                    """.formatted(
+            return "return \"%s[\" + %s + \"]\";"
+                    .formatted(
                     className,
                     fields.stream()
                             .map(field ->


### PR DESCRIPTION
Added a solution to the following: https://github.com/bowbahdoe/magic-bean/issues/6 
The code that's generated in equals, hashCode, toString delegates the call to the super class when there are no fields defined in the annotated bean.
I did not find any unit tests in the project so I did not add a new dependency on a unit test framework (such as junit) therefore I tested the change manually. Let me know if you want unit tests in the project and I can add the dependency and corresponding tests.