### PR TITLE
add gradle snippet to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ Requires Java 17+.
 </dependency>
 ```
 
+### Gradle
+
+```
+dependencies {
+    compileOnly("dev.mccue:magic-bean:3.1.1")
+    annotationProcessor("dev.mccue:magic-bean:3.1.1")
+}
+```
+
 
 ## What this does
 This uses an annotation processor to generate a class which can


### PR DESCRIPTION
addresses #5

This works for both the Groovy and Kotlin DSLs.

The compileOnly configuration is needed to get access to the MagicBean annotation at compile time, while the annotationProcessor configuration informs the compiler to actually use the processor.